### PR TITLE
Fix Neo4j driver CDN path

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
   </main>
 
   <script
-    src="https://cdn.jsdelivr.net/npm/neo4j-driver-lite@5.13.0/browser/neo4j-lite-web.min.js"
+    src="https://cdn.jsdelivr.net/npm/neo4j-driver-lite@5.13.0/lib/browser/neo4j-lite-web.min.js"
     crossorigin="anonymous"
   ></script>
   <script>


### PR DESCRIPTION
## Summary
- update the Neo4j driver script tag to use the correct CDN location so the browser can load the library

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8d894f00c8329a865b0a04b7817cc