### PR TITLE
Fix Neo4j driver CDN path

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
   </main>
 
   <script
-    src="https://cdn.jsdelivr.net/npm/neo4j-driver-lite@5.13.0/lib/browser/neo4j-lite-web.min.js"
+    src="https://cdn.jsdelivr.net/npm/neo4j-driver@5.13.0/lib/browser/neo4j-web.min.js"
     crossorigin="anonymous"
   ></script>
   <script>


### PR DESCRIPTION
## Summary
- switch the script tag to load the officially published neo4j-driver browser bundle from jsDelivr

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8d98ca8048329bf0de622adb128fb