### PR TITLE
Move graph explorer above table and add metadata panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -225,9 +225,16 @@
       font-weight: 600;
     }
 
+    .graph-body {
+      display: flex;
+      flex-wrap: wrap;
+      gap: clamp(1rem, 2.5vw, 1.6rem);
+      align-items: stretch;
+    }
+
     .graph-container {
-      flex: 1 1 auto;
-      min-height: clamp(320px, 40vh, 520px);
+      flex: 1 1 clamp(320px, 55%, 520px);
+      min-height: clamp(320px, 45vh, 540px);
       border-radius: 16px;
       border: 1px dashed rgba(31, 97, 43, 0.24);
       background: rgba(244, 255, 230, 0.58);
@@ -239,6 +246,81 @@
       width: 100%;
       height: 100%;
       font-family: "Fira Code", "Source Code Pro", Menlo, monospace;
+    }
+
+    .graph-details {
+      flex: 1 1 260px;
+      min-width: min(280px, 100%);
+      background: rgba(255, 255, 255, 0.74);
+      border-radius: 16px;
+      border: 1px solid var(--color-border);
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6), 0 18px 32px rgba(23, 72, 38, 0.12);
+      padding: clamp(1rem, 2.4vw, 1.5rem);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .graph-details h3 {
+      margin: 0;
+      font-size: clamp(0.95rem, 2.5vw, 1.1rem);
+      letter-spacing: 0.03em;
+      color: var(--color-primary-dark);
+    }
+
+    .graph-details__content {
+      flex: 1 1 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 0.85rem;
+    }
+
+    .graph-details__name {
+      margin: 0;
+      font-size: clamp(1rem, 2.4vw, 1.2rem);
+      font-weight: 600;
+      color: var(--color-primary);
+      letter-spacing: 0.01em;
+    }
+
+    .graph-details__list {
+      margin: 0;
+      display: grid;
+      gap: 0.85rem;
+    }
+
+    .graph-details__list dt {
+      margin: 0;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(18, 67, 32, 0.58);
+    }
+
+    .graph-details__list dd {
+      margin: 0;
+      font-size: 0.9rem;
+      color: var(--color-muted);
+      line-height: 1.5;
+    }
+
+    .graph-details__list code {
+      display: inline-block;
+      padding: 0.25rem 0.5rem;
+      border-radius: 6px;
+      background: rgba(30, 97, 43, 0.08);
+      font-size: 0.85rem;
+    }
+
+    .graph-details__content .properties {
+      margin: 0;
+    }
+
+    .graph-details__empty {
+      margin: 0;
+      font-size: 0.92rem;
+      color: rgba(18, 67, 32, 0.68);
+      line-height: 1.5;
     }
 
     .graph-link {
@@ -306,6 +388,18 @@
       .graph-section {
         padding: 1.25rem;
       }
+
+      .graph-body {
+        flex-direction: column;
+      }
+
+      .graph-container {
+        min-height: clamp(300px, 50vh, 520px);
+      }
+
+      .graph-details {
+        min-width: 0;
+      }
     }
   </style>
 </head>
@@ -324,6 +418,36 @@
       <div id="status" role="status" aria-live="polite">Ready to connect.</div>
     </section>
 
+    <section class="graph-section" aria-label="Graph explorer">
+      <div class="graph-header">
+        <h2>Graph explorer</h2>
+        <div id="graphStatus" role="status" aria-live="polite">
+          Select a node from the table to explore its relationships.
+        </div>
+      </div>
+      <div class="graph-body">
+        <div
+          id="graphContainer"
+          class="graph-container"
+          role="application"
+          aria-label="Interactive graph visualization"
+        ></div>
+        <aside class="graph-details" aria-labelledby="nodeDetailsTitle">
+          <h3 id="nodeDetailsTitle">Node metadata</h3>
+          <div
+            id="nodeDetails"
+            class="graph-details__content"
+            role="status"
+            aria-live="polite"
+          >
+            <p class="graph-details__empty">
+              Select a node from the table or graph to view its metadata.
+            </p>
+          </div>
+        </aside>
+      </div>
+    </section>
+
     <section class="table-wrapper" aria-live="polite">
       <table>
         <thead>
@@ -340,21 +464,6 @@
           </tr>
         </tbody>
       </table>
-    </section>
-
-    <section class="graph-section" aria-label="Graph explorer">
-      <div class="graph-header">
-        <h2>Graph explorer</h2>
-        <div id="graphStatus" role="status" aria-live="polite">
-          Select a node from the table to explore its relationships.
-        </div>
-      </div>
-      <div
-        id="graphContainer"
-        class="graph-container"
-        role="application"
-        aria-label="Interactive graph visualization"
-      ></div>
     </section>
   </main>
 
@@ -379,6 +488,10 @@
       const nodesBody = document.getElementById("nodesBody");
       const graphContainer = document.getElementById("graphContainer");
       const graphStatus = document.getElementById("graphStatus");
+      const nodeDetails = document.getElementById("nodeDetails");
+
+      const defaultNodeDetailsMessage = "Select a node from the table or graph to view its metadata.";
+      let graphExplorer;
 
       const setStatus = (message, isError = false) => {
         statusElement.textContent = message;
@@ -388,6 +501,61 @@
       const setGraphStatus = (message, isError = false) => {
         graphStatus.textContent = message;
         graphStatus.classList.toggle("error", Boolean(isError));
+      };
+
+      const renderNodeDetails = (node, connectionCount = 0) => {
+        if (!nodeDetails) {
+          return;
+        }
+
+        nodeDetails.innerHTML = "";
+
+        if (!node) {
+          const emptyMessage = document.createElement("p");
+          emptyMessage.className = "graph-details__empty";
+          emptyMessage.textContent = defaultNodeDetailsMessage;
+          nodeDetails.appendChild(emptyMessage);
+          return;
+        }
+
+        const name = document.createElement("p");
+        name.className = "graph-details__name";
+        name.textContent = node.displayName || node.elementId || "(unknown node)";
+        nodeDetails.appendChild(name);
+
+        const list = document.createElement("dl");
+        list.className = "graph-details__list";
+
+        const appendDetail = (label, value) => {
+          const term = document.createElement("dt");
+          term.textContent = label;
+
+          const description = document.createElement("dd");
+          if (value && typeof value === "object" && "nodeType" in value) {
+            description.appendChild(value);
+          } else {
+            description.textContent = String(value);
+          }
+
+          list.appendChild(term);
+          list.appendChild(description);
+        };
+
+        const idCode = document.createElement("code");
+        idCode.textContent = node.elementId || "(unknown)";
+        appendDetail("Element ID", idCode);
+
+        const labelsText = Array.isArray(node.labels) && node.labels.length ? node.labels.join(", ") : "(no labels)";
+        appendDetail("Labels", labelsText);
+
+        appendDetail("Connections in view", connectionCount);
+
+        const propertiesPre = document.createElement("pre");
+        propertiesPre.className = "properties";
+        propertiesPre.textContent = JSON.stringify(node.properties || {}, null, 2);
+        appendDetail("Properties", propertiesPre);
+
+        nodeDetails.appendChild(list);
       };
 
       const setLoading = (isLoading) => {
@@ -656,6 +824,7 @@
           this.linkIndex.clear();
           this.loadedNodes.clear();
           this.activeNodeId = null;
+          renderNodeDetails(null);
           this.update();
         }
 
@@ -716,6 +885,9 @@
         setActiveNode(nodeId) {
           this.activeNodeId = nodeId;
           this.refreshNodeState();
+          const activeNode = nodeId ? this.nodeIndex.get(nodeId) : null;
+          const connectionCount = activeNode ? this.countConnections(nodeId) : 0;
+          renderNodeDetails(activeNode || null, connectionCount);
         }
 
         refreshNodeState() {
@@ -817,7 +989,8 @@
         }
       }
 
-      const graphExplorer = new GraphExplorer(graphContainer);
+      graphExplorer = new GraphExplorer(graphContainer);
+      renderNodeDetails(null);
 
       const loadNeighborsForNode = async (node, options = {}) => {
         const { announceIfLoaded = true } = options;


### PR DESCRIPTION
## Summary
- reposition the graph explorer above the table and add a side panel for focused node metadata
- update the graph layout styles to support the new panel and responsive behavior
- render metadata for the active node via GraphExplorer so the details stay in sync with the visualization

## Testing
- no automated tests (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8e05c2a64832986b58e57a064b3cf