### PR TITLE
Focus first node in table on load

### DIFF
--- a/index.html
+++ b/index.html
@@ -762,6 +762,8 @@
           return;
         }
 
+        let firstFocusableRow = null;
+
         records.forEach((record, index) => {
           const node = record.get("n");
           const formattedNode = formatNode(node);
@@ -770,6 +772,10 @@
           row.dataset.elementId = formattedNode.elementId;
           row.tabIndex = 0;
           row.setAttribute("role", "button");
+
+          if (index === 0) {
+            firstFocusableRow = row;
+          }
 
           const indexCell = document.createElement("td");
           indexCell.textContent = String(index + 1);
@@ -806,6 +812,24 @@
 
           nodesBody.appendChild(row);
         });
+
+        if (firstFocusableRow && typeof firstFocusableRow.focus === "function") {
+          const focusRow = () => {
+            try {
+              firstFocusableRow.focus({ preventScroll: true });
+            } catch (error) {
+              firstFocusableRow.focus();
+            }
+          };
+
+          if (typeof requestAnimationFrame === "function") {
+            requestAnimationFrame(() => {
+              focusRow();
+            });
+          } else {
+            setTimeout(focusRow, 0);
+          }
+        }
       };
 
       const getNeo4jDriver = () => {


### PR DESCRIPTION
## Summary
- store the first rendered node row during table construction
- automatically focus the first node row after records load to improve keyboard navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb8ba75d5c8329a2643c422edea441